### PR TITLE
Task 13 : backendに対するユニットテストを追加

### DIFF
--- a/backend-ts/src/test/getEmployee.test.ts
+++ b/backend-ts/src/test/getEmployee.test.ts
@@ -1,7 +1,21 @@
-test("getEmployeesのテスト(id検索)", async () => {
+test("getEmployeesのテスト(id検索-1)", async () => {
     const { EmployeeDatabaseInMemory } = await import("../employee/EmployeeDatabaseInMemory");
     const db = new EmployeeDatabaseInMemory();
     const employee = await db.getEmployee("1");
     expect(employee).toEqual({ id: "1", name: "Jane Doe", age: 22 });
+});
+
+test("getEmployeesのテスト(id検索-2)", async () => {
+    const { EmployeeDatabaseInMemory } = await import("../employee/EmployeeDatabaseInMemory");
+    const db = new EmployeeDatabaseInMemory();
+    const employee = await db.getEmployee("2");
+    expect(employee).toEqual({ id: "2", name: "John Smith", age: 28 });
+});
+
+test("getEmployeesのテスト(id検索-3)", async () => {
+    const { EmployeeDatabaseInMemory } = await import("../employee/EmployeeDatabaseInMemory");
+    const db = new EmployeeDatabaseInMemory();
+    const employee = await db.getEmployee("3");
+    expect(employee).toEqual({ id: "3", name: "山田 太郎", age: 27 });
 });
 

--- a/backend-ts/src/test/getEmployee.test.ts
+++ b/backend-ts/src/test/getEmployee.test.ts
@@ -1,0 +1,7 @@
+test("getEmployeesのテスト(id検索)", async () => {
+    const { EmployeeDatabaseInMemory } = await import("../employee/EmployeeDatabaseInMemory");
+    const db = new EmployeeDatabaseInMemory();
+    const employee = await db.getEmployee("1");
+    expect(employee).toEqual({ id: "1", name: "Jane Doe", age: 22 });
+});
+

--- a/backend-ts/src/test/getEmployees.test.ts
+++ b/backend-ts/src/test/getEmployees.test.ts
@@ -1,0 +1,39 @@
+
+test("getEmployeesのテスト(空文字列)", async () => {
+    const { EmployeeDatabaseInMemory } = await import("../employee/EmployeeDatabaseInMemory");
+    const db = new EmployeeDatabaseInMemory();
+    const employees = await db.getEmployees("");
+    expect(employees.length).toBe(3);//現在のところ，表示順は未定義
+
+});
+
+test("getEmployeesのテスト(氏名完全一致-1)", async () => {
+    const { EmployeeDatabaseInMemory } = await import("../employee/EmployeeDatabaseInMemory");
+    const db = new EmployeeDatabaseInMemory();
+    const employees = await db.getEmployees("Jane Doe");
+    expect(employees.length).toBe(1);
+    expect(employees[0]).toEqual({ id: "1", name: "Jane Doe", age: 22 });
+});
+
+test("getEmployeesのテスト(氏名完全一致-2)", async () => {
+    const { EmployeeDatabaseInMemory } = await import("../employee/EmployeeDatabaseInMemory");
+    const db = new EmployeeDatabaseInMemory();
+    const employees = await db.getEmployees("John Smith");
+    expect(employees.length).toBe(1);
+    expect(employees[0]).toEqual({ id: "2", name: "John Smith", age: 28 });
+});
+
+test("getEmployeesのテスト(氏名完全一致-3)", async () => {
+    const { EmployeeDatabaseInMemory } = await import("../employee/EmployeeDatabaseInMemory");
+    const db = new EmployeeDatabaseInMemory();
+    const employees = await db.getEmployees("山田 太郎");
+    expect(employees.length).toBe(1);
+    expect(employees[0]).toEqual({ id: "3", name: "山田 太郎", age: 27 });
+});
+
+test("getEmployeesのテスト(氏名完全一致-存在しない氏名)", async () => {
+    const { EmployeeDatabaseInMemory } = await import("../employee/EmployeeDatabaseInMemory");
+    const db = new EmployeeDatabaseInMemory();
+    const employees = await db.getEmployees("未定義　太郎");
+    expect(employees.length).toBe(0);
+});

--- a/cdk-ts/package-lock.json
+++ b/cdk-ts/package-lock.json
@@ -1742,12 +1742,14 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -1978,6 +1980,7 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/constructs": {
@@ -3491,6 +3494,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -3864,6 +3868,7 @@
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"


### PR DESCRIPTION
## 概要

Backend部分の社員を検索する関数を実装しました．

## 詳細

テストケース用のファイルの増加に備え，`\backend-ts\src\test`にバックエンド用のテストファイルを追加しました．
getEmployeeのテスト(getEmployee.test.ts)では，起動時にある3人の社員のIDについて，
getEmployeesのテスト(getEmployees.test.ts)では，
- 起動時にある3人の社員名
- 全員(引数に空文字列を指定した場合)
- 存在しない氏名を入力した場合

の3ケースについてテストを行いました．

いずれのケースにおいても，テストが通過することを確認しています．

## 生成AIの利用について

getEmployee.test.ts，getEmployees.test.tsの双方において，GitHub  Copilotによるコード補完を行いました．
