### PR TITLE
Task 17:CIの導入

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -27,7 +27,8 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'
-    - run: npm ci
+    - run: cd backend-ts && npm i
+    - run: cd frontend && npm i
     - run: npm run build --if-present
     - run: cd backend-ts && npm test
-    - run: cd frontend-ts && npm test
+    - run: cd frontend && npm test

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -29,6 +29,7 @@ jobs:
         cache: 'npm'
     - run: cd backend-ts && npm i
     - run: cd frontend && npm i
-    - run: npm run build --if-present
+    - run: cd frontend && npm run build --if-present
+    - run: cd backend-ts && npm run build --if-present
     - run: cd backend-ts && npm test
     - run: cd frontend && npm test

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -41,7 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     defaults:
       run:
-        working-directory: frontend
+        working-directory: ./frontend
     steps:
       - name: 依存関係のインストール
         run: npm ci

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -27,9 +27,15 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'
-    - run: cd backend-ts && npm i
-    - run: cd frontend && npm i
-    - run: cd frontend && npm run build --if-present
-    - run: cd backend-ts && npm run build --if-present
-    - run: cd backend-ts && npm test
-    - run: cd frontend && npm test
+    - name: 依存関係のインストール(バックエンド)
+      run: cd backend-ts && npm ci    
+    - name: 依存関係のインストール(フロントエンド)
+      run: cd frontend && npm ci
+    - name: フロントエンドのビルド
+      run: cd frontend && npm run build --if-present
+    - name: バックエンドのビルド
+      run: cd backend-ts && npm run build --if-present
+    - name: ユニットテスト(バックエンド)
+      run: cd backend-ts && npm test
+    - name: ユニットテスト(フロントエンド)
+      run: cd frontend && npm test

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -39,10 +39,20 @@ jobs:
     name: CI(フロントエンド)
     needs: build
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [22.x , 20.x]
+        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
     defaults:
       run:
-        working-directory: ./frontend
+        working-directory: frontend
     steps:
+      - uses: actions/checkout@v4
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'npm'
       - name: 依存関係のインストール
         run: npm ci
       - name: ビルド

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -17,7 +17,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.9.2]
+        node-version: [22.16.0]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -17,7 +17,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [22.16.0]
+        node-version: [22.x , 20.x, 18.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -11,15 +11,17 @@ on:
     branches: [ "main" ]
 
 jobs:
-  build:
-
+  backend-Ci:
+    name: CI(バックエンド)
     runs-on: ubuntu-latest
 
     strategy:
       matrix:
         node-version: [22.x , 20.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
-
+    defaults:
+      run:
+        working-directory: frontend
     steps:
     - uses: actions/checkout@v4
     - name: Use Node.js ${{ matrix.node-version }}
@@ -27,17 +29,15 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'
-    - name: 依存関係のインストール(バックエンド)
-      run: cd backend-ts && npm ci    
-    - name: バックエンドのビルド
-      run: cd backend-ts && npm run build --if-present
-    - name: ユニットテスト(バックエンド)
-      run: cd backend-ts && npm test
+    - name: 依存関係のインストール
+      run: npm ci    
+    - name: ビルド
+      run: npm run build --if-present
+    - name: ユニットテスト
+      run: npm test
     
   Frontend-Ci:
-
     name: CI(フロントエンド)
-    needs: build
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -21,7 +21,7 @@ jobs:
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
     defaults:
       run:
-        working-directory: frontend
+        working-directory: backend-ts
     steps:
     - uses: actions/checkout@v4
     - name: Use Node.js ${{ matrix.node-version }}
@@ -32,7 +32,7 @@ jobs:
     - name: 依存関係のインストール
       run: npm ci    
     - name: ビルド
-      run: npm run build --if-present
+      run: npm run build
     - name: ユニットテスト
       run: npm test
     
@@ -56,6 +56,6 @@ jobs:
       - name: 依存関係のインストール
         run: npm ci
       - name: ビルド
-        run: npm run build --if-present
+        run: npm run build
       - name: ユニットテスト
         run: npm test

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -5,7 +5,7 @@ name: Node.js CI
 
 on:
   push:
-    branches: [ "main" ,"devCI" ]
+    branches: [ "main" ]
 
   pull_request:
     branches: [ "main" ]

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -1,0 +1,33 @@
+# This workflow will do a clean installation of node dependencies, cache/restore them, build the source code and run tests across different versions of node
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-nodejs
+
+name: Node.js CI
+
+on:
+  push:
+    branches: [ "main" ,"devCI" ]
+
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [18.x, 20.x, 22.x]
+        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v4
+      with:
+        node-version: ${{ matrix.node-version }}
+        cache: 'npm'
+    - run: npm ci
+    - run: npm run build --if-present
+    - run: cd backend-ts && npm test
+    - run: cd frontend-ts && npm test

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -17,7 +17,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [22.x , 20.x, 18.x]
+        node-version: [22.x , 20.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -17,7 +17,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.x, 20.x, 22.x]
+        node-version: [10.9.2]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -29,13 +29,23 @@ jobs:
         cache: 'npm'
     - name: 依存関係のインストール(バックエンド)
       run: cd backend-ts && npm ci    
-    - name: 依存関係のインストール(フロントエンド)
-      run: cd frontend && npm ci
-    - name: フロントエンドのビルド
-      run: cd frontend && npm run build --if-present
     - name: バックエンドのビルド
       run: cd backend-ts && npm run build --if-present
     - name: ユニットテスト(バックエンド)
       run: cd backend-ts && npm test
-    - name: ユニットテスト(フロントエンド)
-      run: cd frontend && npm test
+    
+  Frontend-Ci:
+
+    name: CI(フロントエンド)
+    needs: build
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - name: 依存関係のインストール
+        run: cd frontend && npm ci
+      - name: ビルド
+        run: cd frontend && npm run build --if-present
+      - name: ユニットテスト
+        run: cd frontend && npm test

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -44,8 +44,8 @@ jobs:
         working-directory: frontend
     steps:
       - name: 依存関係のインストール
-        run: cd frontend && npm ci
+        run: npm ci
       - name: ビルド
-        run: cd frontend && npm run build --if-present
+        run: npm run build --if-present
       - name: ユニットテスト
-        run: cd frontend && npm test
+        run: npm test

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "workspace",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}


### PR DESCRIPTION
## 概要
mainブランチへのプルリクエスト・プッシュ時にCIを行うようにしました．

## 詳細

mainブランチへプルリクエストを行う，もしくはmainブランチにプッシュを行ったときに，フロントエンド，バックエンドの両方について，CIを行うようにしました．

CIでは，Nodeバージョン22,20に対してテストが行われます．

また，CIで落ちた時にどこで詰まっているかをわかりやすくする目的で，各ステップに日本語で名前を付ける工夫をしました．

## 生成AIの利用について

node.js.ymlについて，GitHub Copilotによるコード補完を行いました．

devCIブランチでCIが通過することを確認しています．

