### PR TITLE
ダークモードの実装

### DIFF
--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { AppRouterCacheProvider } from "@mui/material-nextjs/v15-appRouter";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
+import { ThemeManager } from "../components/ThemeManager";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -26,7 +27,12 @@ export default function RootLayout({
   return (
     <html lang="ja">
       <body className={`${geistSans.variable} ${geistMono.variable}`}>
-        <AppRouterCacheProvider>{children}</AppRouterCacheProvider>
+        <AppRouterCacheProvider>
+          {/* ThemeManagerでchildrenをラップする */}
+          <ThemeManager>
+            {children}
+          </ThemeManager>
+        </AppRouterCacheProvider>
       </body>
     </html>
   );

--- a/frontend/src/components/GlobalContainer.tsx
+++ b/frontend/src/components/GlobalContainer.tsx
@@ -1,6 +1,5 @@
 import { Container } from "@mui/material";
 import { VerticalSpacer } from "../components/VerticalSpacer";
-import { GlobalHeader } from "../components/GlobalHeader";
 import { GlobalFooter } from "../components/GlobalFooter";
 
 export function GlobalContainer({ children }: { children?: React.ReactNode }) {
@@ -8,9 +7,6 @@ export function GlobalContainer({ children }: { children?: React.ReactNode }) {
     <Container
       sx={{ display: "flex", flexDirection: "column", minHeight: "100vh" }}
     >
-      <header>
-        <GlobalHeader title={"タレントマネジメントシステム"} />
-      </header>
 
       <VerticalSpacer height={32} />
 

--- a/frontend/src/components/GlobalHeader.tsx
+++ b/frontend/src/components/GlobalHeader.tsx
@@ -1,15 +1,22 @@
-import { AppBar, Box, Toolbar, Typography } from "@mui/material";
+"use client";
+
+import { AppBar, Box, Toolbar, Typography, IconButton } from "@mui/material";
 import PeopleIcon from "@mui/icons-material/People";
+import Brightness4Icon from "@mui/icons-material/Brightness4";
+import Brightness7Icon from "@mui/icons-material/Brightness7";
 import Link from "next/link";
+import { useThemeManager } from "./ThemeManager";
 
 export interface GlobalHeaderProps {
   title: string;
 }
 
 export function GlobalHeader({ title }: GlobalHeaderProps) {
+  const { mode, toggleColorMode } = useThemeManager();
+
   return (
     <Box sx={{ flexGrow: 1 }}>
-      <AppBar position="static">
+      <AppBar position="sticky">
         <Toolbar
           variant="dense"
           sx={{
@@ -17,14 +24,26 @@ export function GlobalHeader({ title }: GlobalHeaderProps) {
               "linear-gradient(45deg, rgb(0, 91, 172), rgb(94, 194, 198))",
           }}
         >
-          <Link href="/">
-            <PeopleIcon fontSize={"large"} sx={{ mr: 2 }} />
+          <Link href="/" passHref>
+            <PeopleIcon fontSize={"large"} sx={{ mr: 2, color: "white" }} />
           </Link>
-          <Link href="/">
-            <Typography variant="h6" component="h1" sx={{ flexGrow: 1 }}>
+          <Link href="/" passHref>
+            <Typography
+              variant="h6"
+              component="h1"
+              sx={{ flexGrow: 1, color: "white" }}
+            >
               {title}
             </Typography>
           </Link>
+          <IconButton
+            edge="end"
+            color="inherit"
+            onClick={toggleColorMode}
+            sx={{ ml: 2 }}
+          >
+            {mode === "dark" ? <Brightness4Icon /> : <Brightness7Icon />}
+          </IconButton>
         </Toolbar>
       </AppBar>
     </Box>

--- a/frontend/src/components/ThemeManager.tsx
+++ b/frontend/src/components/ThemeManager.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import React, { createContext, useContext, useMemo, useState } from "react";
+import { ThemeProvider, createTheme } from "@mui/material/styles";
+import CssBaseline from "@mui/material/CssBaseline";
+import { PaletteMode } from "@mui/material";
+import { GlobalHeader } from "./GlobalHeader";
+import { GlobalContainer } from "./GlobalContainer";
+
+const ThemeContext = createContext({
+  mode: "light" as "light" | "dark",
+  toggleColorMode: () => {},
+});
+
+export function ThemeManager({ children }: { children: React.ReactNode }) {
+  const [mode, setMode] = useState<PaletteMode>("light");
+
+  const toggleColorMode = () => {
+    setMode((prevMode) => (prevMode === "light" ? "dark" : "light"));
+  };
+
+  const theme = useMemo(
+    () =>
+      createTheme({
+        palette: {
+          mode,
+        },
+      }),
+    [mode]
+  );
+
+  return (
+    <ThemeContext.Provider value={{ mode, toggleColorMode }}>
+      <ThemeProvider theme={theme}>
+        <CssBaseline />
+        <GlobalHeader
+          title="タレントマネジメントシステム"
+        />
+        <GlobalContainer>{children}</GlobalContainer>
+      </ThemeProvider>
+    </ThemeContext.Provider>
+  );
+}
+
+export const useThemeManager = () => useContext(ThemeContext);


### PR DESCRIPTION
### 概要
ダークモードを実装しました。

### 詳細
アプリタイトルの横に太陽のアイコンを表示し、それを押すとダークモードに切り替えます。
ダークモード実装する過程で、ヘッダーの表示が変わってしまったが、修正できなかった。

### 生成AIの利用について
GitHub Copilotによるコード補完とエラーの解消を行いました。